### PR TITLE
Don't expose allowed origins on resources that support credentials

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -120,7 +120,7 @@ module Rack
         def initialize(public_resource, path, opts={})
           self.path        = path
           self.methods     = ensure_enum(opts[:methods]) || [:get]
-          self.credentials = opts[:credentials] || true
+          self.credentials = opts[:credentials].nil? ? true : opts[:credentials]
           self.max_age     = opts[:max_age] || 1728000
           self.pattern     = compile(path)
           @public_resource = public_resource
@@ -146,7 +146,7 @@ module Rack
 
         def to_headers(env)
           x_origin = env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
-          h = { 'Access-Control-Allow-Origin' => public_resource? ? '*' : env['HTTP_ORIGIN'],
+          h = { 'Access-Control-Allow-Origin' => credentials ? env['HTTP_ORIGIN'] : public_resource? ? '*' : env['HTTP_ORIGIN'],
             'Access-Control-Allow-Methods'    => methods.collect{|m| m.to_s.upcase}.join(', '),
             'Access-Control-Expose-Headers'   => expose.nil? ? '' : expose.join(', '),
             'Access-Control-Max-Age'          => max_age.to_s }

--- a/test/cors_test.rb
+++ b/test/cors_test.rb
@@ -87,6 +87,12 @@ class CorsTest < Test::Unit::TestCase
     should '* origin should allow any origin' do
       preflight_request('http://locohost:3000', '/public')
       assert_cors_success
+      assert_equal 'http://locohost:3000', last_response.headers['Access-Control-Allow-Origin']
+    end
+
+    should '* origin should allow any origin, and set * if no credentials required' do
+      preflight_request('http://locohost:3000', '/public_without_credentials')
+      assert_cors_success
       assert_equal '*', last_response.headers['Access-Control-Allow-Origin']
     end
 

--- a/test/test.ru
+++ b/test/test.ru
@@ -19,6 +19,7 @@ use Rack::Cors do
   allow do
     origins '*'
     resource '/public'
+    resource '/public_without_credentials', :credentials => false
   end
 end
 


### PR DESCRIPTION
According to the [latest CORS spec](http://www.w3.org/TR/2010/WD-cors-20100727/) preflight response should set
Access-Control-Allow-Origin header to '*' only if resource doesn't support
credentials (Section ["5.2 Preflight request"](http://www.w3.org/TR/2010/WD-cors-20100727/#resource-preflight-requests), step 7).
