### PR TITLE
Adding "Vary" header to response

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -49,7 +49,13 @@ module Rack
         end
       end
       status, headers, body = @app.call env
-      headers = headers.merge(cors_headers) if cors_headers
+      if cors_headers
+        headers = headers.merge(cors_headers)
+        unless headers['Access-Control-Allow-Origin'] == '*'
+          vary = headers['Vary']
+          headers['Vary'] = ((vary ? vary.split(/,\s*/) : []) + ['Origin']).uniq.join(', ')
+        end
+      end
       [status, headers, body]
     end
 

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -43,6 +43,20 @@ class CorsTest < Test::Unit::TestCase
     assert_equal 'expose-test-1, expose-test-2', last_response.headers['Access-Control-Expose-Headers']
   end
 
+  should 'add Vary header if Access-Control-Allow-Origin header was added and if it is specific' do
+    cors_request '/', :origin => "http://192.168.0.3:8080"
+    assert_cors_success
+    assert_equal 'http://192.168.0.3:8080', last_response.headers['Access-Control-Allow-Origin']
+    assert_not_nil last_response.headers['Vary'], 'missing Vary header'
+  end
+
+  should 'not add Vary header if Access-Control-Allow-Origin header was added and if it is generic (*)' do
+    cors_request '/public_without_credentials', :origin => "http://192.168.1.3:8080"
+    assert_cors_success
+    assert_equal '*', last_response.headers['Access-Control-Allow-Origin']
+    assert_nil last_response.headers['Vary'], 'no expecting Vary header'
+  end
+
   context 'preflight requests' do
     should 'fail if origin is invalid' do
       preflight_request('http://allyourdataarebelongtous.com', '/')


### PR DESCRIPTION
This change is important to grant browser's cache to revalidate the content when the "Origin" is different. We have a system-of-systems architecture with different hosts, and we found some trouble with cached JSON response when switch between apps. This fix solves the problem.

Best regards.

Marcelo Manzan.
