### PR TITLE
Check for block_given? in initialization

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -6,10 +6,12 @@ module Rack
       @app = app
       @logger = opts[:logger]
 
-      if block.arity == 1
-        block.call(self)
-      else
-        instance_eval(&block)
+      if block_given?
+        if block.arity == 1
+          block.call(self)
+        else
+          instance_eval(&block)
+        end
       end
     end
 


### PR DESCRIPTION
This is a very small thing but it confused me at first. I followed the instructions on http://blog.nadigs.net/mark/2012/10/16/rails-and-cross-origin-resource-sharing-cors/ to configure my Rails app by putting this in my application.rb:

``` ruby
config.middleware.use Rack::Cors do
  ...
end

config.middleware.insert_before Warden::Manager, Rack::Cors
```

I got an error `rack-cors-0.2.7/lib/rack/cors.rb:9:in `initialize': undefined method `arity' for nil:NilClass (NoMethodError)` on app startup. It took some debugging in the gem and further reading before I realized this is the wrong way to do it. Chalk it up to my unfamiliarity with Rack. You're supposed to do it like this:

``` ruby
config.middleware.insert_before Warden::Manager, Rack::Cors do
  ...
end
```

My commit checks for `block_given?`, which is always a good idea anyway.

I'd also be willing to update the Readme with instructions on how to use Rack::Cors correctly with Devise/Warden. Unless you think that should go into the Devise docs.
