### PR TITLE
Add support for fallback

### DIFF
--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -1,8 +1,10 @@
+require 'test/unit'
 require 'rubygems'
 require 'rack/test'
 require 'shoulda'
 require 'mocha'
 require 'rack/cors'
+require 'debugger'
 
 Rack::Test::Session.class_eval do
   def options(uri, params = {}, env = {}, &block)
@@ -57,6 +59,13 @@ class CorsTest < Test::Unit::TestCase
 
   should 'not add Vary header if Access-Control-Allow-Origin header was added and if it is generic (*)' do
     cors_request '/public_without_credentials', :origin => "http://192.168.1.3:8080"
+    assert_cors_success
+    assert_equal '*', last_response.headers['Access-Control-Allow-Origin']
+    assert_nil last_response.headers['Vary'], 'no expecting Vary header'
+  end
+
+  should 'not add Vary header if Access-Control-Allow-Origin header was added and if it is not in the whitelist and fallback is set to true' do
+    cors_request '/fallback', :origin => "http://192.168.1.3:8080"
     assert_cors_success
     assert_equal '*', last_response.headers['Access-Control-Allow-Origin']
     assert_nil last_response.headers['Vary'], 'no expecting Vary header'

--- a/test/unit/dsl_test.rb
+++ b/test/unit/dsl_test.rb
@@ -54,4 +54,16 @@ class DSLTest < Test::Unit::TestCase
     resources = cors.send :all_resources
     assert resources.first.allow_origin?('file://')
   end
+
+  should 'support setting of fallback' do
+    cors = Rack::Cors.new(Proc.new {}) do |cfg|
+      cfg.allow do |allow|
+        allow.origins 'localhost:3000'
+        allow.fallback true
+        allow.resource '/get-only', :methods => :get
+      end
+    end
+    resources = cors.send :all_resources
+    assert_equal true, resources.first.instance_variable_get(:@fallback)
+  end
 end

--- a/test/unit/test.ru
+++ b/test/unit/test.ru
@@ -28,6 +28,12 @@ use Rack::Cors do
     resource '/public'
     resource '/public_without_credentials', :credentials => false
   end
+
+  allow do
+    fallback true
+    origins 'localhost:3000'
+    resource '/fallback', :methods => :get
+  end
 end
 
 map '/' do


### PR DESCRIPTION
This patch addresses a bug we found with our Backbone app. For Backbone
to set the cookie it requires non-wildcard CORS header to be returned,
but we also needed to support wildcard access for other clients.

So this patch adds fallback config parameter that if set allows
returning of explicit origin host for whitelisted domains, but that also
returns '*' header for other domains.

Also required test/unit in tests as tests didn't seem to run before.
