### PR TITLE
Set log level of fallback logger to DEBUG

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -68,7 +68,7 @@ module Rack
       def debug(env, message = nil, &block)
         if @debug_mode
           logger = @logger || env['rack.logger'] || begin
-            @logger = ::Logger.new(STDOUT).tap {|logger| logger.level = ::Logger::Severity::INFO}
+            @logger = ::Logger.new(STDOUT).tap {|logger| logger.level = ::Logger::Severity::DEBUG}
           end
           logger.debug(message, &block)
         end


### PR DESCRIPTION
The log level of the fallback logger is set to INFO which causes debug log messages in the gem to be ignored.

Please merge this change to debug messages are working with the fallback logger.

Thanks!
