### PR TITLE
warn on :any for methods

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -164,7 +164,7 @@ module Rack
 
         def initialize(public_resource, path, opts={})
           self.path        = path
-          self.methods     = ensure_enum(opts[:methods]) || [:get]
+          self.methods     = prepare_and_validate_methods_option(opts[:methods]) || [:get]
           self.credentials = opts[:credentials].nil? ? true : opts[:credentials]
           self.max_age     = opts[:max_age] || 1728000
           self.pattern     = compile(path)
@@ -234,6 +234,11 @@ module Rack
               request_headers = request_headers.split(/,\s*/) if request_headers.kind_of?(String)
               request_headers.all?{|h| headers.include?(h.downcase)}
             end
+          end
+
+          def prepare_and_validate_methods_option setting
+            raise ArgumentError.new("rack-cors methods must be an single HTTP verb, or an array of verbs") if setting && setting == :any
+            ensure_enum setting
           end
 
           def ensure_enum(v)


### PR DESCRIPTION
Thanks for rack-cors!

I wasted quite a bit of time today because I copied this example:

```
    resource '/public/*', :headers => :any, :methods => :get
```

and switched it to `:methods => :any` without a second thought.

```
    resource '*', :headers => :any, :methods => :any
```

Then spent a long time wondering why it wasn't working. This PR simply
stops people making the same mistake, and upholds the [principle of least astonishment](http://en.wikipedia.org/wiki/Principle_of_least_astonishment).
