### PR TITLE
Allow both "file://" and "null" origins when `origin "file://"` is configured

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -34,7 +34,6 @@ module Rack
     end
 
     def call(env)
-      env['HTTP_ORIGIN'] = 'file://' if env['HTTP_ORIGIN'] == 'null'
       env['HTTP_ORIGIN'] ||= env['HTTP_X_ORIGIN']
 
       cors_headers = nil
@@ -145,11 +144,14 @@ module Rack
 
         def allow_origin?(source,env = {})
           return true if public_resources?
+
+          effective_source = (source == 'null' ? 'file://' : source)
+
           return !! @origins.detect do |origin|
             if origin.is_a?(Proc)
               origin.call(source,env)
             else
-              origin === source
+              origin === effective_source
             end
           end
         end
@@ -207,7 +209,7 @@ module Rack
 
           def origin_for_response_header(origin)
             return '*' if public_resource? && !credentials
-            origin == 'file://' ? 'null' : origin
+            origin
           end
 
           def to_preflight_headers(env)

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -195,6 +195,12 @@ describe Rack::Cors do
       last_response.headers['Access-Control-Allow-Origin'].must_equal 'null'
     end
 
+    it 'should return "file://" as header with "file://" as origin' do
+      preflight_request('file://', '/')
+      should_render_cors_success
+      last_response.headers['Access-Control-Allow-Origin'].must_equal 'file://'
+    end
+
     it 'should return a Content-Type' do
       preflight_request('http://localhost:3000', '/')
       should_render_cors_success


### PR DESCRIPTION
This addresses the problem described in #53 by moving the code that considers "file://" and "null" equivalent down into the origin check, thus preserving the original `Origin` header to be used in `Access-Control-Allow-Origin`.

There's a test included (which passes). One of the existing tests fails intermittently for me, but that is true without this patch as well.
