### PR TITLE
remove unused variable

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -333,7 +333,6 @@ module Rack
         end
 
         def to_headers(env)
-          x_origin = env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
           h = {
             'Access-Control-Allow-Origin'     => origin_for_response_header(env[ORIGIN_HEADER_KEY]),
             'Access-Control-Allow-Methods'    => methods.collect{|m| m.to_s.upcase}.join(', '),


### PR DESCRIPTION
this removes the following Ruby warning:
```
rack-cors-0.4.0/lib/rack/cors.rb:336: warning: assigned but unused variable - x_origin
```