### PR TITLE
Handle arrays of vary headers

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -117,7 +117,7 @@ module Rack
         else
           DEFAULT_VARY_HEADERS
         end
-        headers[VARY] = ((vary ? vary.split(/,\s*/) : []) + cors_vary_headers).uniq.join(', ')
+        headers[VARY] = ((vary ? ([vary].flatten.map { |v| v.split(/,\s*/) }.flatten) : []) + cors_vary_headers).uniq.join(', ')
       end
 
       if debug? && result = env[RACK_CORS]


### PR DESCRIPTION
Headers in Rack may be arrays of values. If that is the case with the vary header, then rack-cors will fail when attempting to `split` it.

This change handles the vary header when it is both a string and an array.
