### PR TITLE
Add change where Rails 5 accepts class rather than string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,19 @@ module YourApp
   class Application < Rails::Application
 
     # ...
+    
+    # Rails 3/4
 
     config.middleware.insert_before 0, "Rack::Cors" do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
+    
+    # Rails 5
+
+    config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'
         resource '*', :headers => :any, :methods => [:get, :post, :options]


### PR DESCRIPTION
Fixes an issue in the README where Rails 5 accepts class rather than string.