### PR TITLE
Keep null origins from masquarding as "file://"

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -278,13 +278,11 @@ module Rack
         def allow_origin?(source,env = {})
           return true if public_resources?
 
-          effective_source = (source == 'null' ? 'file://' : source)
-
           return !! @origins.detect do |origin|
             if origin.is_a?(Proc)
               origin.call(source,env)
             else
-              origin === effective_source
+              origin === source
             end
           end
         end
@@ -323,7 +321,7 @@ module Rack
           else
             ensure_enum(opts[:methods]) || [:get]
           end.map{|e| e.to_s }
-          
+
           self.expose = opts[:expose] ? [opts[:expose]].flatten : nil
         end
 

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -256,12 +256,6 @@ describe Rack::Cors do
       last_response.headers['Access-Control-Allow-Origin'].must_equal '*'
     end
 
-    it 'should "null" origin, allowed as "file://", returned as "null" in header' do
-      preflight_request('null', '/')
-      should_render_cors_success
-      last_response.headers['Access-Control-Allow-Origin'].must_equal 'null'
-    end
-
     it 'should return "file://" as header with "file://" as origin' do
       preflight_request('file://', '/')
       should_render_cors_success


### PR DESCRIPTION
Browsers send null origins when an iframe contains html code for its
source instead of a URL. This means that websites who used rack-cors and
allowed "file://" were open to attacks from malicious pages that used
this fact to send "null" origins.