### PR TITLE
Prevent insecure CORS configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,6 @@ module YourApp
 
     # ...
     
-    # Rails 3/4
-
-    config.middleware.insert_before 0, "Rack::Cors" do
-      allow do
-        origins '*'
-        resource '*', :headers => :any, :methods => [:get, :post, :options]
-      end
-    end
-    
     # Rails 5
 
     config.middleware.insert_before 0, Rack::Cors do
@@ -46,10 +37,20 @@ module YourApp
       end
     end
 
+    # Rails 3/4
+
+    config.middleware.insert_before 0, "Rack::Cors" do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
+    
   end
 end
 ```
-Refer to [rails 3 example](https://github.com/cyu/rack-cors/tree/master/examples/rails3) and [rails 4 example](https://github.com/cyu/rack-cors/tree/master/examples/rails4) for more details.
+
+We use `insert_before` to make sure `Rack::Cors` runs at the beginning of the stack to make sure it isn't interfered with with other middleware (see `Rack::Cache` note in **Common Gotchas** section). Check out the [rails 4 example](https://github.com/cyu/rack-cors/tree/master/examples/rails4) and [rails 3 example](https://github.com/cyu/rack-cors/tree/master/examples/rails3).
 
 See The [Rails Guide to Rack](http://guides.rubyonrails.org/rails_on_rack.html) for more details on rack middlewares or watch the [railscast](http://railscasts.com/episodes/151-rack-middleware).
 

--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -298,11 +298,14 @@ module Rack
       end
 
       class Resource
+        class CorsMisconfiguartionError < StandardError; end
+
         attr_accessor :path, :methods, :headers, :expose, :max_age, :credentials, :pattern, :if_proc, :vary_headers
 
         def initialize(public_resource, path, opts={})
+          raise CorsMisconfiguartionError if public_resource && opts[:credentials]
           self.path         = path
-          self.credentials  = opts[:credentials].nil? ? true : opts[:credentials]
+          self.credentials  = opts[:credentials].nil? ? !public_resource : opts[:credentials]
           self.max_age      = opts[:max_age] || 1728000
           self.pattern      = compile(path)
           self.if_proc      = opts[:if]
@@ -354,7 +357,7 @@ module Rack
           end
 
           def origin_for_response_header(origin)
-            return '*' if public_resource? && !credentials
+            return '*' if public_resource?
             origin
           end
 

--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -298,12 +298,18 @@ module Rack
       end
 
       class Resource
-        class CorsMisconfiguartionError < StandardError; end
+        class CorsMisconfigurationError < StandardError
+          def message
+            "Allowing credentials for wildcard origins is insecure."\
+            " Please specify more restrictive origins or set 'credentials' to false in your CORS configuration."
+          end
+        end
 
         attr_accessor :path, :methods, :headers, :expose, :max_age, :credentials, :pattern, :if_proc, :vary_headers
 
         def initialize(public_resource, path, opts={})
-          raise CorsMisconfiguartionError if public_resource && opts[:credentials]
+          raise CorsMisconfigurationError if public_resource && opts[:credentials]
+
           self.path         = path
           self.credentials  = opts[:credentials].nil? ? !public_resource : opts[:credentials]
           self.max_age      = opts[:max_age] || 1728000

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -136,6 +136,11 @@ describe Rack::Cors do
     cors_request '/conditional', :origin => 'http://192.168.0.1:1234'
   end
 
+  it "should not allow credentials for public resources" do
+    cors_request '/public'
+    last_response.headers['Access-Control-Allow-Credentials'].must_be_nil
+  end
+
  describe 'logging' do
     it 'should not log debug messages if debug option is false' do
       app = mock
@@ -266,6 +271,14 @@ describe Rack::Cors do
       preflight_request('http://localhost:3000', '/')
       should_render_cors_success
       last_response.headers['Content-Type'].wont_be_nil
+    end
+  end
+
+  describe "with insecure configuration" do
+    let(:app) { load_app('insecure') }
+
+    it "should raise an error" do
+      proc { cors_request '/public' }.must_raise Rack::Cors::Resource::CorsMisconfigurationError
     end
   end
 

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -247,7 +247,7 @@ describe Rack::Cors do
     it 'should * origin should allow any origin' do
       preflight_request('http://locohost:3000', '/public')
       should_render_cors_success
-      last_response.headers['Access-Control-Allow-Origin'].must_equal 'http://locohost:3000'
+      last_response.headers['Access-Control-Allow-Origin'].must_equal '*'
     end
 
     it 'should * origin should allow any origin, and set * if no credentials required' do
@@ -314,7 +314,7 @@ describe Rack::Cors do
 
     it "should return original headers if in debug" do
       cors_request origin: "http://example.net"
-      last_response.headers['X-Rack-CORS-Original-Access-Control-Allow-Origin'].must_equal "http://example.net"
+      last_response.headers['X-Rack-CORS-Original-Access-Control-Allow-Origin'].must_equal "*"
     end
   end
 

--- a/test/unit/insecure.ru
+++ b/test/unit/insecure.ru
@@ -1,0 +1,8 @@
+require 'rack/cors'
+
+use Rack::Cors do
+  allow do
+    origins '*'
+    resource '/public', credentials: true
+  end
+end


### PR DESCRIPTION
This PR fixes #126.
Main changes:
* Specifying a wildcard origin in combination with 'allow credentials' isn't allowed anymore.
* `credentials` defaults to true iff the specified origin is not the wildcard.
* Origin mirroring only occurs if no origin wildcard was used.