### PR TITLE
Remove unnecessary :require option from Gemfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install the gem:
 Or in your Gemfile:
 
 ```ruby
-gem 'rack-cors', require: 'rack/cors'
+gem 'rack-cors'
 ```
 
 


### PR DESCRIPTION
`Bundler.require` automatically loads lib/rack/cors.rb even if there is no :require option.

This can be verified by the following code:

```rb
require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "rack-cors"
end

puts defined?(Rack::Cors) #=> constant
```

cf. https://guides.rubygems.org/name-your-gem/