### PR TITLE
Fix possible frozen hash mutation

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -117,7 +117,7 @@ module Rack
         else
           DEFAULT_VARY_HEADERS
         end
-        headers[VARY] = ((vary ? vary.split(/,\s*/) : []) + cors_vary_headers).uniq.join(', ')
+        headers = headers.merge(VARY => ((vary ? vary.split(/,\s*/) : []) + cors_vary_headers).uniq.join(', '))
       end
 
       if debug? && result = env[RACK_CORS]

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -55,7 +55,7 @@ describe Rack::Cors do
       eval File.read(File.dirname(__FILE__) + "/#{name}.ru")
       map('/') do
         run proc { |env|
-          [200, {'Content-Type' => 'text/html'}, ['success']]
+          [200, {'Content-Type' => 'text/html'}.freeze, ['success'].freeze]
         }
       end
     end


### PR DESCRIPTION
rack-cors can raise runtime error when the headers hash returned by app is frozen.