### PR TITLE
Add an :if example to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ use Rack::Cors do
   allow do
     origins '*'
     resource '/public/*', headers: :any, methods: :get
+
+    # Only allow a request for a specific host
+    resource '/api/v1/*',
+        headers: :any,
+        methods: :get,
+        if: proc { |env| env['HTTP_HOST'] == 'api.example.com' }
   end
 end
 ```


### PR DESCRIPTION
Based on https://github.com/cyu/rack-cors/issues/70#issuecomment-75392790

I wanted to figure out how to add a host constraint to a resource. I missed the `:if` option when skimming the README, so I had to search the issues. I think this would be a helpful tip