### PR TITLE
Remove Content-Type header from preflight OPTIONS response

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -19,7 +19,6 @@ module Rack
     OPTIONS      = 'OPTIONS'.freeze
     VARY         = 'Vary'.freeze
     CONTENT_TYPE = 'Content-Type'.freeze
-    TEXT_PLAIN   = 'text/plain'.freeze
 
     DEFAULT_VARY_HEADERS = ['Origin'].freeze
 
@@ -363,7 +362,7 @@ module Rack
         end
 
         def process_preflight(env, result)
-          headers = {CONTENT_TYPE => TEXT_PLAIN}
+          headers = {}
 
           request_method = env[HTTP_ACCESS_CONTROL_REQUEST_METHOD]
           if request_method.nil?

--- a/rack-cors.gemspec
+++ b/rack-cors.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16.0"
+  spec.add_development_dependency "bundler", ">= 1.16.0", '< 3'
   spec.add_development_dependency "rake", "~> 12.3.0"
   spec.add_development_dependency "minitest", "~> 5.11.0"
   spec.add_development_dependency "mocha", "~> 1.6.0"

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -353,12 +353,6 @@ describe Rack::Cors do
       last_response.headers['Access-Control-Allow-Origin'].must_equal 'file://'
     end
 
-    it 'should return a Content-Type' do
-      preflight_request('http://localhost:3000', '/')
-      last_response.must_render_cors_success
-      last_response.headers['Content-Type'].wont_be_nil
-    end
-
     describe '' do
 
       let(:app) do
@@ -372,7 +366,7 @@ describe Rack::Cors do
             end
           end
           map('/') do
-            run ->(env) { [500, {'Content-Type' => 'text/plain'}, ['FAIL!']] }
+            run ->(env) { [500, {}, ['FAIL!']] }
           end
         end
       end
@@ -429,7 +423,7 @@ describe Rack::Cors do
           end
         end
         map('/') do
-          run ->(env) { [200, {'Content-Type' => 'text/plain', 'Access-Control-Allow-Origin' => 'http://foo.net'}, ['success']] }
+          run ->(env) { [200, {'Access-Control-Allow-Origin' => 'http://foo.net'}, ['success']] }
         end
       end
     end


### PR DESCRIPTION
Rack-cors used to set `Content-Type` header to `text/plain` on preflight requests. It was added [9 years ago](https://github.com/cyu/rack-cors/commit/7b67da387a6efd9ed0928a727e61dd52578c1f61) because rack spec required it at that time.
In 2012, rack spec was [updated](https://github.com/rack/rack/commit/2138f0b9ad37e625b48e4214fa24126de7917335), so `Content-Type` header is no longer required.
The reason why someone would need for this header to be removed is new [CORB protection](https://www.chromium.org/Home/chromium-security/corb-for-developers). If you check its description [here](https://fetch.spec.whatwg.org/#corb), you'll see that response to OPTIONS request with `text/plain` header will be blocked. Blocking does not affect any functionality, it just shows an error in Chrome console. But to get rid of these messages, preflight response headers should not include `Content-Type` header.

*I also released bundler dependency, because it was quite restricted and referred to an outdated version of bundler.*