### PR TITLE
Reduce default max_age to a more sensible value

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -330,7 +330,7 @@ module Rack
 
           self.path         = path
           self.credentials  = public_resource ? false : (opts[:credentials] == true)
-          self.max_age      = opts[:max_age] || 1728000
+          self.max_age      = opts[:max_age] || 7200
           self.pattern      = compile(path)
           self.if_proc      = opts[:if]
           self.vary_headers = opts[:vary] && [opts[:vary]].flatten


### PR DESCRIPTION
Browsers cap the value of Access-Control-Max-Age, Chromium being the most aggressive at 2 hours:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
https://cs.chromium.org/chromium/src/services/network/public/cpp/cors/preflight_result.cc?rcl=49e7c0b4886cac1f3d09dc046bd528c9c811a0fa&l=28-31

It sounds logical to set a default value that all browsers will honor.