### PR TITLE
Fix example link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ module YourApp
 end
 ```
 
-We use `insert_before` to make sure `Rack::Cors` runs at the beginning of the stack to make sure it isn't interfered with by other middleware (see `Rack::Cache` note in **Common Gotchas** section). Check out the [rails 4 example](https://github.com/cyu/rack-cors/tree/master/examples/rails4) and [rails 3 example](https://github.com/cyu/rack-cors/tree/master/examples/rails3).
+We use `insert_before` to make sure `Rack::Cors` runs at the beginning of the stack to make sure it isn't interfered with by other middleware (see `Rack::Cache` note in **Common Gotchas** section). Check out the [rails 5 example](https://github.com/cyu/rack-cors/tree/master/examples/rails5).
 
 See The [Rails Guide to Rack](http://guides.rubyonrails.org/rails_on_rack.html) for more details on rack middlewares or watch the [railscast](http://railscasts.com/episodes/151-rack-middleware).
 


### PR DESCRIPTION
The rails 4 and rails 3 examples are no longer here, replaced with rails 5 example.