### PR TITLE
add Ruby 3.x to travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - '3.0'
+  - 3.1
   - truffleruby-head
 
 script:


### PR DESCRIPTION
Ruby 3.0 has been out for [over a year](https://www.ruby-lang.org/en/downloads/branches/). Tests all pass in Ruby 3.0 and 3.1. We should add those to the versions the CI runs against.