### PR TITLE
Refs #251, 862a776 Remove Rack::Utils::HeaderHash

### DIFF
--- a/lib/rack/cors/resource.rb
+++ b/lib/rack/cors/resource.rb
@@ -66,7 +66,7 @@ module Rack
           'access-control-max-age' => max_age.to_s
         }
         h['access-control-allow-credentials'] = 'true' if credentials
-        Rack::Utils::HeaderHash.new(h)
+        h
       end
 
       protected


### PR DESCRIPTION
  The Rack::Utils::HeaderHash was removed by Rack on the commit:

    rack/rack@a5762cf#diff-85960cbd609e7f51a9881d1876b82d748f4ba8312a31e3329a5bb9bf791c60be