### PR TITLE
Changelog: Fix date on 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## 2.0.0 - 2022-09-11
+## 2.0.0 - 2023-02-14
 ### Changed
 - Refactored codebase
 - Support declaring custom protocols in origin


### PR DESCRIPTION
This confused me for a sec when I was reviewing our dependency updates 😀 

Looks like 2.0.0 was pushed on 2023-02-14, not 2022-09-11.