### PR TITLE
Update badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rack CORS Middleware [![Build Status](https://travis-ci.org/cyu/rack-cors.svg?branch=master)](https://travis-ci.org/cyu/rack-cors)
+# Rack CORS Middleware [![Build Status](https://github.com/cyu/rack-cors/actions/workflows/ci.yaml/badge.svg)](https://github.com/cyu/rack-cors/actions)
 
 `Rack::Cors` provides support for Cross-Origin Resource Sharing (CORS) for Rack compatible web applications.
 


### PR DESCRIPTION
Sorry, https://github.com/cyu/rack-cors/pull/256 has missed updating README badge. It's nice to have show the latest CI status instead of outdated TravisCI status.

ref https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge