### PR TITLE
Escape $ in ressource paths compile

### DIFF
--- a/lib/rack/cors/resource.rb
+++ b/lib/rack/cors/resource.rb
@@ -106,7 +106,7 @@ module Rack
 
       def compile(path)
         if path.respond_to? :to_str
-          special_chars = %w[. + ( )]
+          special_chars = %w[. + ( ) $]
           pattern =
             path.to_str.gsub(%r{((:\w+)|/\*|[\*#{special_chars.join}])}) do |match|
               case match

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -351,6 +351,13 @@ describe Rack::Cors do
       _(last_response.headers['Access-Control-Allow-Origin']).must_equal '*'
     end
 
+    it "should allow resource paths containing $ char" do
+      preflight_request('http://localhost:3000', '/$batch', method: :post )
+      _(last_response).must_render_cors_success
+      _(last_response.headers['Access-Control-Allow-Origin']).wont_equal nil
+      _(last_response.headers['Access-Control-Allow-Methods']).must_equal 'POST'
+    end
+
     it "should allow '/<path>/' resource if match pattern is /<path>/*" do
       preflight_request('http://localhost:3000', '/wildcard/')
       _(last_response).must_render_cors_success

--- a/test/unit/test.ru
+++ b/test/unit/test.ru
@@ -23,6 +23,7 @@ use Rack::Cors do
     resource '/conditional', methods: :get, if: proc { |env| !!env['HTTP_X_OK'] }
     resource '/vary_test', methods: :get, vary: %w[Origin Host]
     resource '/patch_test', methods: :patch
+    resource '/$batch', methods: :post
     resource '/wildcard/*', methods: :any
     # resource '/file/at/*',
     #     :methods => [:get, :post, :put, :delete],


### PR DESCRIPTION
This is minimal fix for issue #269 
It's just adding '$'  to special_chars in Ressource.compile
I have added a testcase too 