### PR TITLE
Various docs for 2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.idea
 .yardoc
 /Gemfile.lock
 InstalledFiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## 2.0.2 - 2024-03-04
 ### Changed
 - Fix file permission issues with 2.0.1 release
+  - Security: Fixes CVE-2024-27456, GHSA-785g-282q-pwvx
 
 ## 2.0.1 - 2023-02-17
 ### Changed

--- a/rack-cors.gemspec
+++ b/rack-cors.gemspec
@@ -19,6 +19,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  s.metadata = {
+    'changelog_uri' => 'https://github.com/cyu/rack-cors/blob/master/CHANGELOG.md'
+  }
+
   spec.add_dependency 'rack', '>= 2.0.0'
   spec.add_development_dependency 'bundler', '>= 1.16.0', '< 3'
   spec.add_development_dependency 'minitest', '~> 5.11.0'


### PR DESCRIPTION
Adding the CVE ids to the changelog is the most important part here, IMO. Please feel free to ignore the other two changes.