### PR TITLE
Remove unnecessary mention of RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ has a custom protocol (`chrome-extension://`, `ionic://`, etc.) simply exclude t
 
 For example, instead of specifying `chrome-extension://aomjjhallfgjeglblehebfpbcfeobpga` specify `aomjjhallfgjeglblehebfpbcfeobpga` in `origins`.
 
-As of 2.0.0 (currently in RC1), you can specify origins with a custom protocol.
+As of 2.0.0, you can specify origins with a custom protocol.
 
 ### Rails 6 Host Matching
 


### PR DESCRIPTION
2.0.0 has already been released so remove the mention of "currently RC1".