### PR TITLE
Fix error loading gemspec

### DIFF
--- a/rack-cors.gemspec
+++ b/rack-cors.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  s.metadata = {
+  spec.metadata = {
     'changelog_uri' => 'https://github.com/cyu/rack-cors/blob/master/CHANGELOG.md'
   }
 


### PR DESCRIPTION
Installing dependencies has been failing since the commit 41ccfee introduced an undefined local variable in the gemspec:

```
[!] There was an error parsing `Gemfile`:
[!] There was an error while loading `rack-cors.gemspec`: undefined local variable or method `s' for main:Object. Bundler cannot continue.

 #  from /home/runner/work/rack-cors/rack-cors/rack-cors.gemspec:22
 #  -------------------------------------------
 #
 >    s.metadata = {
 #      'changelog_uri' => 'https://github.com/cyu/rack-cors/blob/master/CHANGELOG.md'
 #  -------------------------------------------
. Bundler cannot continue.

 #  from /home/runner/work/rack-cors/rack-cors/Gemfile:6
 #  -------------------------------------------
 #  # Specify your gem's dependencies in rack-cors.gemspec
 >  gemspec
 #
 #  -------------------------------------------
```