### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/rack-cors

### DIFF
--- a/rack-cors.gemspec
+++ b/rack-cors.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  s.metadata = {
+  spec.metadata = {
     'changelog_uri' => 'https://github.com/cyu/rack-cors/blob/master/CHANGELOG.md'
   }
 


### PR DESCRIPTION
Due to a typo the current configuration there isn't a 'Changelog' link showing on https://rubygems.org/gems/rack-cors