### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/rack-cors.gemspec
+++ b/rack-cors.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.metadata = {
-    'changelog_uri' => 'https://github.com/cyu/rack-cors/blob/master/CHANGELOG.md'
+    'changelog_uri' => 'https://github.com/cyu/rack-cors/blob/master/CHANGELOG.md',
+    'funding_uri' => 'https://github.com/sponsors/cyu'
   }
 
   spec.add_dependency 'rack', '>= 2.0.0'


### PR DESCRIPTION
I noticed that you are already on GitHub Sponsors. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.