### PR TITLE
Adjust resource wildcard matching

### DIFF
--- a/lib/rack/cors/resource.rb
+++ b/lib/rack/cors/resource.rb
@@ -108,10 +108,12 @@ module Rack
         if path.respond_to? :to_str
           special_chars = %w[. + ( ) $]
           pattern =
-            path.to_str.gsub(%r{((:\w+)|/\*|[\*#{special_chars.join}])}) do |match|
+            path.to_str.gsub(%r{((:\w+)|/\*\*|/\*|[\*#{special_chars.join}])}) do |match|
               case match
+              when '/**'
+                '(?:/.*)?' # Match anything after '/'
               when '/*'
-                '\\/?(.*?)'
+                '(?:/([^/]*?))?' # Match one segment after '/' or nothing
               when '*'
                 '(.*?)'
               when *special_chars


### PR DESCRIPTION
### 📝 Description

 e.g. `/data/*` no longer matches `/database`.

This should resolve https://github.com/cyu/rack-cors/issues/282.

I came across the same problem described in that issue and ended up specifying each resource separately instead of using a wildcard. Although this is a valid workaround, let's try to get resource wildcard matching to behave? I have also added some tests that (hopefully) should speak for themselves.