### PR TITLE
Add `logger` gem as an explicit dependency

### DIFF
--- a/rack-cors.gemspec
+++ b/rack-cors.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
     'funding_uri' => 'https://github.com/sponsors/cyu'
   }
 
+  spec.add_dependency 'logger'
   spec.add_dependency 'rack', '>= 2.0.0'
   spec.add_development_dependency 'bundler', '>= 1.16.0', '< 3'
   spec.add_development_dependency 'minitest', '~> 5.11.0'


### PR DESCRIPTION
`logger` will be a bundled gem from Ruby 3.5.
https://bugs.ruby-lang.org/issues/20309

So if we use `logger` as the standard library, Bundler shows the following warning.

```
src/github.com/cyu/rack-cors/lib/rack/cors.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

This PR adds the `logger` to explicit dependency to fix the warning.