### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
           - truffleruby-head
     runs-on: ubuntu-latest
     steps:

--- a/rack-cors.gemspec
+++ b/rack-cors.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rack', '>= 2.0.0'
   spec.add_development_dependency 'bundler', '>= 1.16.0', '< 3'
-  spec.add_development_dependency 'minitest', '~> 5.11.0'
-  spec.add_development_dependency 'mocha', '~> 1.6.0'
+  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'pry', '~> 0.12'
   spec.add_development_dependency 'rack-test', '>= 1.1.0'
   spec.add_development_dependency 'rake', '~> 12.3.0'


### PR DESCRIPTION
This PR adds Ruby 3.4 to the test matrix to ensure to work the gem with it.

This PR updates `minitest` and `mocha` versions to support Ruby 3.4